### PR TITLE
Enable setting the allocation size threshold for heaptrack_preload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build*/
 *.zst
 *.AppImage
 heaptrack_test/target
+
+# VSCode
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+>
+> **This is a forked version of [KDE/heaptrack](https://github.com/KDE/heaptrack) with [additional features](#extension).**
+>
+>
+
 # heaptrack - a heap memory profiler for Linux
 
 ![heaptrack_gui summary page](screenshots/gui_summary.png?raw=true "heaptrack_gui summary page")
@@ -242,3 +248,34 @@ will see garbage backtraces that are completely broken.
 If you encounter such issues, try to relink your application and also libunwind with `ld.bfd` instead of `ld.gold`.
 You can see if you are affected by running the libunwind unit tests via `make check`. But do note that you
 need to relink your application too, not only libunwind.
+
+## <a id="extension"></a>Additional features
+
+### Allocation size threshold
+
+If `heaptrack` started tracing from the beginning of the profiled application
+with an environment variable `HEAPTRACK_PRELOAD_ALLOC_SIZE_THRESHOLD` set,
+**`heaptrack` will NOT trace any heap memory allocation with the size
+smaller than `HEAPTRACK_PRELOAD_ALLOC_SIZE_THRESHOLD` bytes**.
+
+#### Example
+
+```
+$ HEAPTRACK_PRELOAD_ALLOC_SIZE_THRESHOLD=1024 heaptrack <your application and its parameters>
+```
+
+### Function name blacklist
+
+If `heaptrack` started tracing from the beginning of the profiled application
+with an environment variable `HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST` set,
+**`heaptrack` will NOT trace any heap memory allocation if current call stack contains
+some return pointers to some functions listed in `HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST`**.
+
+In `HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST`,
+function names should be delimited by `':'`, `' '`(space character) or `'\n'`(newline character).
+
+#### Example
+
+```
+$ HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST=foo:bar:foobar heaptrack <your application and its parameters>
+```

--- a/src/track/CMakeLists.txt
+++ b/src/track/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(heaptrack_preload LINK_PRIVATE
     ${LIBUTIL_LIBRARY}
     heaptrack_unwind
     rt
+    tsl::robin_map
 )
 
 set_target_properties(heaptrack_preload PROPERTIES

--- a/src/track/heaptrack_inject.cpp
+++ b/src/track/heaptrack_inject.cpp
@@ -74,10 +74,6 @@ __attribute__((weak)) void* mi_realloc(void* p, size_t newsize) LIBC_FUN_ATTRS;
 __attribute__((weak)) void mi_free(void* p) LIBC_FUN_ATTRS;
 }
 
-extern "C" {
-    heaptrack_3rd_config_t ht3config = {0, 0, 2, {}, {}};
-}
-
 namespace {
 
 namespace Elf {

--- a/src/track/heaptrack_inject.cpp
+++ b/src/track/heaptrack_inject.cpp
@@ -74,6 +74,10 @@ __attribute__((weak)) void* mi_realloc(void* p, size_t newsize) LIBC_FUN_ATTRS;
 __attribute__((weak)) void mi_free(void* p) LIBC_FUN_ATTRS;
 }
 
+extern "C" {
+    heaptrack_3rd_config_t ht3config = {0, 0, 2, {}, {}};
+}
+
 namespace {
 
 namespace Elf {
@@ -538,7 +542,7 @@ extern "C" {
 void heaptrack_inject(const char* outputFileName) noexcept
 {
     heaptrack_init(
-        outputFileName, 0, &overwrite_symbols, [](LineWriter& out) { out.write("A\n"); }, &restore_symbols);
+        outputFileName, &overwrite_symbols, [](LineWriter& out) { out.write("A\n"); }, &restore_symbols);
 }
 }
 
@@ -553,7 +557,7 @@ struct HeaptrackInjectPreloadInitialization
             // when the env var wasn't set, then this means we got runtime injected, don't do anything here
             return;
         }
-        heaptrack_init(outputFileName, 0, &overwrite_symbols, nullptr, &restore_symbols);
+        heaptrack_init(outputFileName, &overwrite_symbols, nullptr, &restore_symbols);
     }
 };
 

--- a/src/track/heaptrack_inject.cpp
+++ b/src/track/heaptrack_inject.cpp
@@ -538,7 +538,7 @@ extern "C" {
 void heaptrack_inject(const char* outputFileName) noexcept
 {
     heaptrack_init(
-        outputFileName, &overwrite_symbols, [](LineWriter& out) { out.write("A\n"); }, &restore_symbols);
+        outputFileName, 0, &overwrite_symbols, [](LineWriter& out) { out.write("A\n"); }, &restore_symbols);
 }
 }
 
@@ -553,7 +553,7 @@ struct HeaptrackInjectPreloadInitialization
             // when the env var wasn't set, then this means we got runtime injected, don't do anything here
             return;
         }
-        heaptrack_init(outputFileName, &overwrite_symbols, nullptr, &restore_symbols);
+        heaptrack_init(outputFileName, 0, &overwrite_symbols, nullptr, &restore_symbols);
     }
 };
 

--- a/src/track/heaptrack_preload.cpp
+++ b/src/track/heaptrack_preload.cpp
@@ -16,10 +16,6 @@
 #include <atomic>
 #include <type_traits>
 
-extern "C" {
-    heaptrack_3rd_config_t ht3config;
-}
-
 using namespace std;
 
 #if defined(_ISOC11_SOURCE)
@@ -173,17 +169,17 @@ void init()
     // Setting allocation size threshold
     const char *const allocSizeThresholdEnv = getenv("HEAPTRACK_PRELOAD_ALLOC_SIZE_THRESHOLD");
     if (allocSizeThresholdEnv) {
-        ht3config.allocSizeThreshold = atoi(allocSizeThresholdEnv);
+        ht3config().allocSizeThreshold = atoi(allocSizeThresholdEnv);
     } else {
-        ht3config.allocSizeThreshold = 0;
+        ht3config().allocSizeThreshold = 0;
     }
 
     // Setting function name blacklist
     const char *const funcNameFilterEnv = getenv("HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST");
     if (funcNameFilterEnv) {
         unsigned int maxLength = 0;
-        const char **funcNameStringsCursor = ht3config.funcNameStrings;
-        unsigned int *funcNameLengthsCursor = ht3config.funcNameLengths;
+        const char **funcNameStringsCursor = ht3config().funcNameStrings;
+        unsigned int *funcNameLengthsCursor = ht3config().funcNameLengths;
         const char *pc = funcNameFilterEnv;
         const char *funcNameString = pc;
         while (true) {
@@ -196,8 +192,8 @@ void init()
                         maxLength = *funcNameLengthsCursor;
                     }
                     funcNameLengthsCursor++;
-                    ht3config.numFuncName++;
-                    if (ht3config.numFuncName == HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE) {
+                    ht3config().numFuncName++;
+                    if (ht3config().numFuncName == HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE) {
                         break;
                     }
                 }
@@ -208,9 +204,9 @@ void init()
             }
             pc++;
         }
-        ht3config.maxLengthPlusTwo = maxLength + 2;
+        ht3config().maxLengthPlusTwo = maxLength + 2;
     } else {
-        ht3config.numFuncName = 0;
+        ht3config().numFuncName = 0;
     }
     
     heaptrack_init(

--- a/src/track/heaptrack_preload.cpp
+++ b/src/track/heaptrack_preload.cpp
@@ -165,8 +165,14 @@ void init()
     // heaptrack_init itself calls calloc via std::mutex/_libpthread_init on FreeBSD
     hooks::calloc.original = &dummy_calloc;
     hooks::calloc.init();
+    const char *allocSizeThresholdEnv = getenv("HEAPTRACK_PRELOAD_ALLOC_SIZE_THRESHOLD");
+    uint64_t allocSizeThreshold = 0;
+    if (allocSizeThresholdEnv) {
+        allocSizeThreshold = atoi(allocSizeThresholdEnv);
+    }
     heaptrack_init(
         getenv("DUMP_HEAPTRACK_OUTPUT"),
+        allocSizeThreshold,
         [] {
             hooks::dlopen.init();
             hooks::dlclose.init();

--- a/src/track/heaptrack_preload.cpp
+++ b/src/track/heaptrack_preload.cpp
@@ -168,46 +168,11 @@ void init()
 
     // Setting allocation size threshold
     const char *const allocSizeThresholdEnv = getenv("HEAPTRACK_PRELOAD_ALLOC_SIZE_THRESHOLD");
-    if (allocSizeThresholdEnv) {
-        ht3config().allocSizeThreshold = atoi(allocSizeThresholdEnv);
-    } else {
-        ht3config().allocSizeThreshold = 0;
-    }
+    HtExtUtil().setAllocSizeThreshold(allocSizeThresholdEnv);
 
     // Setting function name blacklist
     const char *const funcNameFilterEnv = getenv("HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST");
-    if (funcNameFilterEnv) {
-        unsigned int maxLength = 0;
-        const char **funcNameStringsCursor = ht3config().funcNameStrings;
-        unsigned int *funcNameLengthsCursor = ht3config().funcNameLengths;
-        const char *pc = funcNameFilterEnv;
-        const char *funcNameString = pc;
-        while (true) {
-            if (*pc == ':' || *pc == ' ' || *pc == '\n' || *pc == '\0') {
-                if (pc != funcNameString) {
-                    *funcNameStringsCursor = funcNameString;
-                    funcNameStringsCursor++;
-                    *funcNameLengthsCursor = pc - funcNameString;
-                    if (*funcNameLengthsCursor > maxLength) {
-                        maxLength = *funcNameLengthsCursor;
-                    }
-                    funcNameLengthsCursor++;
-                    ht3config().numFuncName++;
-                    if (ht3config().numFuncName == HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE) {
-                        break;
-                    }
-                }
-                funcNameString = pc + 1;
-                if (*pc == '\0') {
-                    break;
-                }
-            }
-            pc++;
-        }
-        ht3config().maxLengthPlusTwo = maxLength + 2;
-    } else {
-        ht3config().numFuncName = 0;
-    }
+    HtExtUtil().setFunctionNameBlacklist(funcNameFilterEnv);
     
     heaptrack_init(
         getenv("DUMP_HEAPTRACK_OUTPUT"),

--- a/src/track/libheaptrack.cpp
+++ b/src/track/libheaptrack.cpp
@@ -894,8 +894,8 @@ void heaptrack_resume()
 
 bool is_ignored_by_size(size_t size)
 {
-    if (ht3config.allocSizeThreshold) {
-        if (size < ht3config.allocSizeThreshold) {
+    if (ht3config().allocSizeThreshold) {
+        if (size < ht3config().allocSizeThreshold) {
             return true;
         }
     }
@@ -904,7 +904,7 @@ bool is_ignored_by_size(size_t size)
 
 bool is_ignored_by_current_stack()
 {
-    return Trace::isSomeProcListed(ht3config.funcNameStrings, ht3config.funcNameLengths, ht3config.numFuncName, ht3config.maxLengthPlusTwo);
+    return Trace::isSomeProcListed(ht3config().funcNameStrings, ht3config().funcNameLengths, ht3config().numFuncName, ht3config().maxLengthPlusTwo);
 }
 
 void heaptrack_malloc(void* ptr, size_t size)

--- a/src/track/libheaptrack.cpp
+++ b/src/track/libheaptrack.cpp
@@ -892,27 +892,12 @@ void heaptrack_resume()
     HeapTrack::setPaused(false);
 }
 
-bool is_ignored_by_size(size_t size)
-{
-    if (ht3config().allocSizeThreshold) {
-        if (size < ht3config().allocSizeThreshold) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool is_ignored_by_current_stack()
-{
-    return Trace::isSomeProcListed(ht3config().funcNameStrings, ht3config().funcNameLengths, ht3config().numFuncName, ht3config().maxLengthPlusTwo);
-}
-
 void heaptrack_malloc(void* ptr, size_t size)
 {
-    if (is_ignored_by_size(size)) {
+    if (HtExtUtil().isIgnoredByAllocSize(size)) {
         return;
     }
-    if (is_ignored_by_current_stack()) {
+    if (Trace::isSomeProcListed()) {
         return;
     }
     
@@ -941,11 +926,11 @@ void heaptrack_free(void* ptr)
 
 void heaptrack_realloc(void* ptr_in, size_t size, void* ptr_out)
 {
-    if (is_ignored_by_size(size)) {
+    if (HtExtUtil().isIgnoredByAllocSize(size)) {
         heaptrack_free(ptr_in);
         return;
     }
-    if (is_ignored_by_current_stack()) {
+    if (Trace::isSomeProcListed()) {
         heaptrack_free(ptr_in);
         return;
     }

--- a/src/track/libheaptrack.h
+++ b/src/track/libheaptrack.h
@@ -20,15 +20,20 @@ typedef struct LineWriter linewriter_t;
 typedef void (*heaptrack_callback_t)();
 typedef void (*heaptrack_callback_initialized_t)(linewriter_t&);
 
-typedef struct {
-    uint64_t allocSizeThreshold;
-    unsigned int numFuncName;
-    unsigned int maxLengthPlusTwo;
-    const char *funcNameStrings[HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE];
-    unsigned int funcNameLengths[HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE];
-} heaptrack_3rd_config_t;
+struct Ht3rdConfig
+{
+    uint64_t allocSizeThreshold = 0;
+    unsigned int numFuncName = 0;
+    unsigned int maxLengthPlusTwo = 2;
+    const char *funcNameStrings[HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE] = {nullptr};
+    unsigned int funcNameLengths[HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE] = {0};
+};
 
-extern heaptrack_3rd_config_t ht3config;
+__attribute__((weak)) Ht3rdConfig& ht3config()
+{
+    static Ht3rdConfig config;
+    return config;
+}
 
 void heaptrack_init(
     const char* outputFileName,

--- a/src/track/libheaptrack.h
+++ b/src/track/libheaptrack.h
@@ -7,8 +7,11 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+#include <cstdlib>
 
-#define HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE 256
+#define HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST_MAX_NAME_LENGTH 1024
+#define HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST_MAX_LIST_SIZE 256
 
 #ifdef __cplusplus
 typedef class LineWriter linewriter_t;
@@ -20,18 +23,141 @@ typedef struct LineWriter linewriter_t;
 typedef void (*heaptrack_callback_t)();
 typedef void (*heaptrack_callback_initialized_t)(linewriter_t&);
 
-struct Ht3rdConfig
-{
-    uint64_t allocSizeThreshold = 0;
-    unsigned int numFuncName = 0;
-    unsigned int maxLengthPlusTwo = 2;
-    const char *funcNameStrings[HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE] = {nullptr};
-    unsigned int funcNameLengths[HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE] = {0};
+typedef const char *str_ro, *str_ro_probe;
+
+struct FunctionName {
+    str_ro name = nullptr;
+    size_t length = 0;
 };
 
-__attribute__((weak)) Ht3rdConfig& ht3config()
+class FunctionNameBlacklist
 {
-    static Ht3rdConfig config;
+public:
+    enum AddResult {
+        Failure_WasFull,
+        Failure_TooLong,
+        Success_NotFullYet,
+        Success_FullNow,
+    };
+
+    // `name`: non-null
+    AddResult add(str_ro name, size_t length) {
+        if (size >= HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST_MAX_LIST_SIZE) {
+            return Failure_WasFull;
+        }
+        if (length > HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST_MAX_NAME_LENGTH) {
+            return Failure_TooLong;
+        }
+        list[size].name = name;
+        list[size].length = length;
+        size++;
+        if (size >= HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST_MAX_LIST_SIZE) {
+            return Success_FullNow;
+        } else {
+            return Success_NotFullYet;
+        }
+    }
+
+    bool isEmpty() {
+        return size == 0;
+    }
+
+    // `name`: non-null
+    bool contains(str_ro name) {
+        size_t length = strlen(name);
+        for (size_t i = 0; i < size; i++) {
+            if (list[i].length == length) {
+                if (strncmp(list[i].name, name, length) == 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    size_t maxLengthPlusTwo = 2;
+
+private:
+    size_t size = 0;
+    FunctionName list[HEAPTRACK_PRELOAD_FUNCTION_NAME_BLACKLIST_MAX_LIST_SIZE];
+};
+
+class HtExt
+{
+public:
+    void setAllocSizeThreshold(str_ro env) {
+        if (env == nullptr) {
+            threshold = 0;
+        } else {
+            threshold = atoi(env);
+        }
+    }
+
+    void setFunctionNameBlacklist(str_ro env) {
+        if (env == nullptr) {
+            return;
+        }
+        size_t maxLength = 0;
+        str_ro_probe probe = env;
+        str_ro name = probe;
+        while (true) {
+            if (
+                *probe == ':' || *probe == ' ' ||
+                *probe == '\n' || *probe == '\0'
+            ) {
+                if (probe != name) {
+                    size_t length = probe - name;
+                    FunctionNameBlacklist::AddResult addResult = blacklist.add(name, length);
+                    if (addResult == FunctionNameBlacklist::AddResult::Failure_WasFull) {
+                        break;
+                    }
+                    if (addResult != FunctionNameBlacklist::AddResult::Failure_TooLong) {
+                        if (length > maxLength) {
+                            maxLength = length;
+                        }
+                        if (addResult == FunctionNameBlacklist::AddResult::Success_FullNow) {
+                            break;
+                        }
+                    }
+                }
+                name = probe + 1;
+                if (*probe == '\0') {
+                    break;
+                }
+            }
+            probe++;
+        }
+        blacklist.maxLengthPlusTwo = maxLength + 2;
+    }
+
+    bool isIgnoredByAllocSize(size_t size) {
+        if (threshold == 0) {
+            return false;
+        } else {
+            return size < threshold;
+        }
+    }
+
+    bool isFunctionNameBlacklistSet() {
+        return !blacklist.isEmpty();
+    }
+
+    size_t minFunctionNameBufferLengthToSearch() {
+        return blacklist.maxLengthPlusTwo;
+    }
+
+    bool isIgnoredByFuncName(str_ro name) {
+        return blacklist.contains(name);
+    }
+
+private:
+    size_t threshold = 0;
+    FunctionNameBlacklist blacklist;
+};
+
+__attribute__((weak)) HtExt& HtExtUtil()
+{
+    static HtExt config;
     return config;
 }
 

--- a/src/track/libheaptrack.h
+++ b/src/track/libheaptrack.h
@@ -18,7 +18,7 @@ typedef struct LineWriter linewriter_t;
 typedef void (*heaptrack_callback_t)();
 typedef void (*heaptrack_callback_initialized_t)(linewriter_t&);
 
-void heaptrack_init(const char* outputFileName, heaptrack_callback_t initCallbackBefore,
+void heaptrack_init(const char* outputFileName, uint64_t allocSizeThreshold, heaptrack_callback_t initCallbackBefore,
                     heaptrack_callback_initialized_t initCallbackAfter, heaptrack_callback_t stopCallback);
 
 void heaptrack_stop();

--- a/src/track/libheaptrack.h
+++ b/src/track/libheaptrack.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#define HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE 256
+
 #ifdef __cplusplus
 typedef class LineWriter linewriter_t;
 extern "C" {
@@ -18,8 +20,22 @@ typedef struct LineWriter linewriter_t;
 typedef void (*heaptrack_callback_t)();
 typedef void (*heaptrack_callback_initialized_t)(linewriter_t&);
 
-void heaptrack_init(const char* outputFileName, uint64_t allocSizeThreshold, heaptrack_callback_t initCallbackBefore,
-                    heaptrack_callback_initialized_t initCallbackAfter, heaptrack_callback_t stopCallback);
+typedef struct {
+    uint64_t allocSizeThreshold;
+    unsigned int numFuncName;
+    unsigned int maxLengthPlusTwo;
+    const char *funcNameStrings[HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE];
+    unsigned int funcNameLengths[HEAPTRACK_FUNCTION_NAME_FILTER_MAX_SIZE];
+} heaptrack_3rd_config_t;
+
+extern heaptrack_3rd_config_t ht3config;
+
+void heaptrack_init(
+    const char* outputFileName,
+    heaptrack_callback_t initCallbackBefore,
+    heaptrack_callback_initialized_t initCallbackAfter,
+    heaptrack_callback_t stopCallback
+);
 
 void heaptrack_stop();
 

--- a/src/track/trace.h
+++ b/src/track/trace.h
@@ -9,6 +9,9 @@
 
 #include <cassert>
 #include <cstdint>
+#include <cstdlib>
+
+#define HEAPTRACK_PRELOAD_FUNCTION_NAME_FILTER_MAX_LENGTH 1024
 
 /**
  * @brief Backtrace interface.
@@ -70,6 +73,8 @@ struct Trace
     static void setup();
 
     static void print();
+
+    static bool isSomeProcListed(const char **strings, const unsigned int *lengths, unsigned int size, unsigned int maxLength);
 
 private:
     static int unwind(void** data);

--- a/src/track/trace.h
+++ b/src/track/trace.h
@@ -11,8 +11,6 @@
 #include <cstdint>
 #include <cstdlib>
 
-#define HEAPTRACK_PRELOAD_FUNCTION_NAME_FILTER_MAX_LENGTH 1024
-
 /**
  * @brief Backtrace interface.
  */
@@ -74,7 +72,7 @@ struct Trace
 
     static void print();
 
-    static bool isSomeProcListed(const char **strings, const unsigned int *lengths, unsigned int size, unsigned int maxLength);
+    static bool isSomeProcListed();
 
 private:
     static int unwind(void** data);

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -53,6 +53,7 @@ if ("${Boost_FILESYSTEM_FOUND}" AND "${Boost_SYSTEM_FOUND}")
             ${LIBUTIL_LIBRARY}
             heaptrack_unwind
             rt
+            tsl::robin_map
             ${Boost_SYSTEM_LIBRARY}
             ${Boost_FILESYSTEM_LIBRARY}
     )


### PR DESCRIPTION
In some situation, it is important to **reduce the profiling time**. For some application (to profile), this can be achieved by **skipping tracing small heap allocations**. Therefore, I suggest to add a feature which enables skipping tracing heap allocations whose sizes are smaller than <ins>a user-specified value</ins>.

I implemented such feature and <ins>the user-specified value</ins> can be configured by setting an environment variable `HEAPTRACK_PRELOAD_ALLOC_SIZE_THRESHOLD`. As specified in the name of the environment variable, this is implemented **only for cases the user launches the target application and starts tracing from the beginning**(, yet).

Usage:
```
HEAPTRACK_PRELOAD_ALLOC_SIZE_THRESHOLD=1024 heaptrack <your application and its parameters>

heaptrack output will be written to "/tmp/heaptrack.APP.PID.gz"
starting application, this might take some time...

...

heaptrack stats:
    allocations:            65
    leaked allocations:     60
    temporary allocations:  1

Heaptrack finished! Now run the following to investigate the data:

    heaptrack_gui "/tmp/heaptrack.APP.PID.gz"
```